### PR TITLE
Edit MenuItem model, serializer, and URL

### DIFF
--- a/restaurant/models.py
+++ b/restaurant/models.py
@@ -11,3 +11,6 @@ class MenuItem(models.Model):
     title = models.CharField(max_length=255)
     price = models.DecimalField(max_digits=10, decimal_places=2)
     inventory = models.IntegerField()
+
+    def __str__(self):
+        return f"{self.title} : {str(self.price)}"

--- a/restaurant/serializers.py
+++ b/restaurant/serializers.py
@@ -7,6 +7,7 @@ class MenuSerializer(serializers.ModelSerializer):
     class Meta:
         model = MenuItem
         fields = [
+            "id",
             "title",
             "price",
             "inventory",

--- a/restaurant/tests.py
+++ b/restaurant/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/restaurant/urls.py
+++ b/restaurant/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
     path("restaurant/menu", views.MenuItemView.as_view(), name="menu_items"),
     path(
         "restaurant/menu/<int:pk>",
-        views.MenuItemView.as_view(),
+        views.SingleMenuItemView.as_view(),
         name="single_menu_item",
     ),
 ]


### PR DESCRIPTION
Add title field to MenuSerializer.
Define __str__() method of MenuItem model.
Fix routing for the API endpoint for single menu items. Needs to route to the SingleMenuItemView.